### PR TITLE
replace bunx to bun x

### DIFF
--- a/docs/guides/ecosystem/vite.md
+++ b/docs/guides/ecosystem/vite.md
@@ -11,7 +11,7 @@ While Vite currently works with Bun, it has not been heavily optimized, nor has 
 Vite works out of the box with Bun (v0.7 and later). Get started with one of Vite's templates.
 
 ```bash
-$ bunx create-vite my-app
+$ bun x create-vite my-app
 ✔ Select a framework: › React
 ✔ Select a variant: › TypeScript + SWC
 Scaffolding project in /path/to/my-app...
@@ -28,12 +28,12 @@ bun install
 
 ---
 
-Start the development server with the `vite` CLI using `bunx`.
+Start the development server with the `vite` CLI using `bun x`.
 
 The `--bun` flag tells Bun to run Vite's CLI using `bun` instead of `node`; by default Bun respects Vite's `#!/usr/bin/env node` [shebang line](<https://en.wikipedia.org/wiki/Shebang_(Unix)>). After Bun 1.0 this flag will no longer be necessary.
 
 ```bash
-bunx --bun vite
+bun x --bun vite
 ```
 
 ---
@@ -43,7 +43,7 @@ To simplify this command, update the `"dev"` script in `package.json` to the fol
 ```json-diff#package.json
   "scripts": {
 -   "dev": "vite",
-+   "dev": "bunx --bun vite",
++   "dev": "bun x --bun vite",
     "build": "vite build",
     "serve": "vite preview"
   },
@@ -63,7 +63,7 @@ bun run dev
 The following command will build your app for production.
 
 ```sh
-$ bunx --bun vite build
+$ bun x --bun vite build
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->
replace `$ bunx` to `$ bun x`
<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [X] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

<!-- I wrote automated tests -->

<!-- If JavaScript/TypeScript modules or builtins changed: -->

- [X] I ran `bunx` and dosen't worked 
- [X] so I ran `bun x` and it works 




<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
